### PR TITLE
Introduces a reusable git workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,10 +28,11 @@ on:
         required: true
         description: "Public key for signing transactions in the format: `ed25519:<public_key>`"
         type: string
-    secrets:
-      SIGNER_PRIVATE_KEY:
-        description: "Private key in `ed25519:<private_key>` format for signing transaction"
+      signer-private-key:
         required: true
+        description: "Private key in `ed25519:<private_key>` format for signing transaction"
+        type: string
+
 jobs:
   deploy-widgets:
     runs-on: ubuntu-latest
@@ -42,7 +43,7 @@ jobs:
       BOS_DEPLOY_ACCOUNT_ID: ${{ inputs.deploy-account-address }}
       BOS_SIGNER_ACCOUNT_ID: ${{ inputs.signer-account-address }}
       BOS_SIGNER_PUBLIC_KEY: ${{ inputs.signer-public-key }}
-      BOS_SIGNER_PRIVATE_KEY: ${{ secrets.SIGNER_PRIVATE_KEY }}
+      BOS_SIGNER_PRIVATE_KEY: ${{ inputs.signer-private-key }}
 
     steps:
       - name: Checkout repository
@@ -55,12 +56,12 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
-         
+          node-version: "18"
+
       - name: Install bos-workspace globally
         run: |
           npm install -g bos-workspace
-  
+
       - name: Build the workspaces
         run: |
           bos-workspace build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,14 +48,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
       - name: Install near-social CLI
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/FroVolod/bos-cli-rs/releases/download/v${{ inputs.cli-version }}/bos-cli-v${{ inputs.cli-version }}-installer.sh | sh
-
-      - name: Install bos-workspace
+         
+      - name: Install bos-workspace globally
         run: |
-          npm install bos-workspace
-      
+          npm install -g bos-workspace
+  
       - name: Build the workspaces
         run: |
           bos-workspace build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install bos-cli-rs
         run: |
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/FroVolod/bos-cli-rs/releases/download/v${{ inputs.cli-version }}/bos-cli-v${{ inputs.cli-version }}-installer.sh | sh
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/FroVolod/bos-cli-rs/releases/download/v${{ inputs.cli-version }}/bos-cli-installer.sh | sh
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   deploy-widgets:
     runs-on: ubuntu-latest
-    name: Deploy widgets to social.near (mainnet)
+    name: Deploy Widgets
     env:
       BOS_DEPLOY_ENV: ${{ inputs.deploy-env }}
       BOS_APP_NAME: ${{ inputs.app-name }}
@@ -48,14 +48,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Install bos-cli-rs
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/FroVolod/bos-cli-rs/releases/download/v${{ inputs.cli-version }}/bos-cli-v${{ inputs.cli-version }}-installer.sh | sh
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-
-      - name: Install near-social CLI
-        run: |
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/FroVolod/bos-cli-rs/releases/download/v${{ inputs.cli-version }}/bos-cli-v${{ inputs.cli-version }}-installer.sh | sh
          
       - name: Install bos-workspace globally
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy BOS-Workspace App Components
+on:
+  workflow_call:
+    inputs:
+      cli-version:
+        required: false
+        description: "Version of BOS CLI to use for deploy (e.g. 0.3.0)"
+        type: string
+        default: "0.3.6"
+      deploy-env:
+        required: false
+        description: "Environment to deploy component code to (e.g. mainnet, testnet)"
+        type: string
+        default: "mainnet"
+      app-name:
+        required: true
+        description: "Workspace app name to deploy (from /apps directory)"
+        type: string
+      deploy-account-address:
+        required: true
+        description: "Account under which component code should be deployed"
+        type: string
+      signer-account-address:
+        required: true
+        description: "Account which will be used for signing deploy transaction, frequently the same as deploy-account-address"
+        type: string
+      signer-public-key:
+        required: true
+        description: "Public key for signing transactions in the format: `ed25519:<public_key>`"
+        type: string
+    secrets:
+      SIGNER_PRIVATE_KEY:
+        description: "Private key in `ed25519:<private_key>` format for signing transaction"
+        required: true
+jobs:
+  deploy-widgets:
+    runs-on: ubuntu-latest
+    name: Deploy widgets to social.near (mainnet)
+    env:
+      BOS_DEPLOY_ENV: ${{ inputs.deploy-env }}
+      BOS_APP_NAME: ${{ inputs.app-name }}
+      BOS_DEPLOY_ACCOUNT_ID: ${{ inputs.deploy-account-address }}
+      BOS_SIGNER_ACCOUNT_ID: ${{ inputs.signer-account-address }}
+      BOS_SIGNER_PUBLIC_KEY: ${{ inputs.signer-public-key }}
+      BOS_SIGNER_PRIVATE_KEY: ${{ secrets.SIGNER_PRIVATE_KEY }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install near-social CLI
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/FroVolod/bos-cli-rs/releases/download/v${{ inputs.cli-version }}/bos-cli-v${{ inputs.cli-version }}-installer.sh | sh
+
+      - name: Install bos-workspace
+        run: |
+          npm install bos-workspace
+      
+      - name: Build the workspaces
+        run: |
+          bos-workspace build
+
+      - name: Deploy widgets
+        working-directory: ./build/${{ inputs.app-name }}
+        run: |
+          bos components deploy "$BOS_DEPLOY_ACCOUNT_ID" sign-as "$BOS_SIGNER_ACCOUNT_ID" network-config "$BOS_DEPLOY_ENV" sign-with-plaintext-private-key --signer-public-key "$BOS_SIGNER_PUBLIC_KEY" --signer-private-key "$BOS_SIGNER_PRIVATE_KEY" send

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn 
+          cache: yarn
 
       - name: Install Dependencies
         id: install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16
-          cache: yarn 
-          registry-url: 'https://registry.npmjs.org'
+          cache: yarn
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install Dependencies
         id: install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16
-          cache: yarn 
+          cache: yarn
 
       - name: Install Dependencies
         id: install

--- a/README.md
+++ b/README.md
@@ -124,3 +124,58 @@ To exclude files from the `data.json` file, add the `/*__@ignore__*/` comment to
 The jsonc files will be passed through JSON.stringify before being stored in the `data.json` file, the build script will also remove all the comments and spaces from the jsonc files.
 If you want to skip the JSON.stringify operation and keep the structure, add the following comment at the beginning of the file:
 `/*__@noStringify__*/`
+
+
+
+To use the [reusable workflow for deploying your apps](./.gitignore/workflows/deploy.yml) This workspace comes with a reusable workflow for deploying an app.
+
+Here's the cleaned-up documentation in Markdown:
+
+## Deploying Widgets through GitHub Actions
+
+To deploy widgets on push to branch, create a GitHub Actions workflow file in your repository, e.g., `.github/workflows/deploy-embeds-mainnet.yml`, and configure it as follows:
+
+```yaml
+name: Deploy 'AppName' App Components to Mainnet
+
+on:
+  push:
+    branches: [main] // branch for trigger
+
+jobs:
+  deploy-mainnet:
+    uses: NEARBuilders/bos-workspace/.github/workflows/deploy.yml@main
+    with:
+      deploy-env: "mainnet"  // environemnt to deploy to
+      app-name: "embeds" // app name with bos.config.json
+      deploy-account-address: ${{ vars.DEPLOY_ACCOUNT_ID }} // should match bos.config.json (TODO fix this)
+      signer-account-address: ${{ vars.SIGNER_ACCOUNT_ID }} // account to sign with
+      signer-public-key: ${{ vars.SIGNER_PUBLIC_KEY }}
+    secrets:
+      SIGNER_PRIVATE_KEY: ${{ secrets.SIGNER_PRIVATE_KEY }}
+```
+
+Adjust the workflow as needed, then configure your variables + secrets on Github Settings -> Actions -> secrets & variables. Use [near-cli-rs](https://github.com/near/near-cli-rs) for generating keypairs.
+
+
+### Workflow Inputs
+
+The workflow accepts the following inputs:
+
+- `cli-version` (optional): Version of BOS CLI to use for deployment (e.g., 0.3.0). Default: "0.3.6"
+
+- `deploy-env` (optional): Environment to deploy component code to (e.g., mainnet, testnet). Default: "mainnet"
+
+- `app-name` (required): Workspace app name to deploy (from the /apps directory).
+
+- `deploy-account-address` (required): Account under which component code should be deployed.
+
+- `signer-account-address` (required): Account used for signing the deploy transaction, frequently the same as `deploy-account-address`.
+
+- `signer-public-key` (required): Public key for signing transactions in the format: `ed25519:<public_key>`.
+
+### GitHub Secrets
+
+You need to set the following GitHub Secrets in your repository:
+
+- `SIGNER_PRIVATE_KEY`: Private key in `ed25519:<private_key>` format for signing transactions.

--- a/README.md
+++ b/README.md
@@ -151,8 +151,7 @@ jobs:
       deploy-account-address: ${{ vars.DEPLOY_ACCOUNT_ID }} // should match bos.config.json (TODO fix this)
       signer-account-address: ${{ vars.SIGNER_ACCOUNT_ID }} // account to sign with
       signer-public-key: ${{ vars.SIGNER_PUBLIC_KEY }}
-    secrets:
-      SIGNER_PRIVATE_KEY: ${{ secrets.SIGNER_PRIVATE_KEY }}
+      signer-private-key: ${{ secrets.SIGNER_PRIVATE_KEY }}
 ```
 
 Adjust the workflow as needed, then configure your variables + secrets on Github Settings -> Actions -> secrets & variables. Use [near-cli-rs](https://github.com/near/near-cli-rs) for generating keypairs.
@@ -174,8 +173,5 @@ The workflow accepts the following inputs:
 
 - `signer-public-key` (required): Public key for signing transactions in the format: `ed25519:<public_key>`.
 
-### GitHub Secrets
+- `signer-private-key` (required): Private key for signing transactions in the format: `ed25519:<private_key>`.
 
-You need to set the following GitHub Secrets in your repository:
-
-- `SIGNER_PRIVATE_KEY`: Private key in `ed25519:<private_key>` format for signing transactions.

--- a/README.md
+++ b/README.md
@@ -125,8 +125,6 @@ The jsonc files will be passed through JSON.stringify before being stored in the
 If you want to skip the JSON.stringify operation and keep the structure, add the following comment at the beginning of the file:
 `/*__@noStringify__*/`
 
-
-
 To use the [reusable workflow for deploying your apps](./.gitignore/workflows/deploy.yml) This workspace comes with a reusable workflow for deploying an app.
 
 Here's the cleaned-up documentation in Markdown:
@@ -156,7 +154,6 @@ jobs:
 
 Adjust the workflow as needed, then configure your variables + secrets on Github Settings -> Actions -> secrets & variables. Use [near-cli-rs](https://github.com/near/near-cli-rs) for generating keypairs.
 
-
 ### Workflow Inputs
 
 The workflow accepts the following inputs:
@@ -174,4 +171,3 @@ The workflow accepts the following inputs:
 - `signer-public-key` (required): Public key for signing transactions in the format: `ed25519:<public_key>`.
 
 - `signer-private-key` (required): Private key for signing transactions in the format: `ed25519:<private_key>`.
-

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install -g bos-workspace
 
 Then, create a new folder with the following structure:
 
-```
+```js
 - apps
   - {appname}
     - bos.config.json
@@ -49,7 +49,6 @@ Commands:
 ```
 
 > If the gateway can't fetch local components, try disabling brave shields or your adblock.
-
 > If the commands don't work, try again using Node >=16
 
 ## Key Features
@@ -90,7 +89,7 @@ The build script will create a `data.json` file based on the `jsonc` and `txt` f
 
 For instance, consider the following structure:
 
-```
+```js
 - apps
 - {appname}
     - something.txt
@@ -152,7 +151,7 @@ jobs:
       signer-private-key: ${{ secrets.SIGNER_PRIVATE_KEY }}
 ```
 
-Adjust the workflow as needed, then configure your variables + secrets on Github Settings -> Actions -> secrets & variables. Use [near-cli-rs](https://github.com/near/near-cli-rs) for generating keypairs.
+Adjust the workflow as needed, then configure your variables + secrets on GitHub Settings -> Actions -> secrets & variables. Use [near-cli-rs](https://github.com/near/near-cli-rs) for generating keypairs.
 
 ### Workflow Inputs
 


### PR DESCRIPTION
_Resolves #25_

[SEE IT IN USE HERE](https://github.com/NEARBuilders/embeds/blob/main/.github/workflows/release.yml)

Workflow takes in the following inputs:

```
    inputs:
      cli-version:
        required: false
        description: "Version of BOS CLI to use for deploy (e.g. 0.3.0)"
        type: string
        default: "0.3.6"
      deploy-env:
        required: false
        description: "Environment to deploy component code to (e.g. mainnet, testnet)"
        type: string
        default: "mainnet"
      app-name:
        required: true
        description: "Workspace app name to deploy (from /apps directory)"
        type: string
      deploy-account-address:
        required: true
        description: "Account under which component code should be deployed"
        type: string
      signer-account-address:
        required: true
        description: "Account which will be used for signing deploy transaction, frequently the same as deploy-account-address"
        type: string
      signer-public-key:
        required: true
        description: "Public key for signing transactions in the format: `ed25519:<public_key>`"
        type: string
    secrets:
      SIGNER_PRIVATE_KEY:
        description: "Private key in `ed25519:<private_key>` format for signing transaction"
        required: true
```

* It allows to be passed environment (so can be reused for mainnet, testnet, and preview deploy)
* It takes in an app name, so workflows can be created per app  

It currently downloads and installs bos-cli-rs; it may be an improvement to replace with a bos deploy command (but bos deploy should be able to take app name)