### PR TITLE
Adds feedback and fixes an init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist/**/*
 
 # ignore yarn.lock
 yarn.lock
+
+# tests
+__app_example_1/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# bos-workspace
+
+## Getting started
+
+Clone and build locally 
+
+```cmd
+git clone https://github.com/NEARBuilders/bos-workspace.git#1.0.0.wip
+yarn build
+```
+
+go where you need to create a project
+
+```cmd
+./relative/path/bos-workspace/bin/bw.js init buildbox
+```
+
+this will create a project. Navigate into it:
+
+```cmd
+cd buildbox
+/relative/path/bos-workspace/bin/bw.js dev
+```
+
+Feedback:
+
+- [ ] build after testing throws tsc error
+- [ ] init without project name throws error "[path] argument is required"
+- [x] home doesn't run because "hello" is not a function (need to default VM.require, fix in "init")
+- [ ] socket connects and disconnects, why? nice error logging
+- [ ] how could bw init be configured with template repositories? -- also, for easy integration, init structure should match/work with bos components download (I think mv ./widget ./src/widget, configs stay where they are)
+- [ ] newly initialized typescript files are throwing errors, want to include package.json, eslint, tsconfig, etc... (open to choose typescript or javascript)
+- [ ] I think module/hello should match: module.hello rather than hello.module
+- [ ] I really like the alias pattern -- alias/name, config/account, module/hello
+- [ ] We could prompt the account name during bw init
+- [ ] Idk what error, but hot-reload was killed once during editing (exception handling)
+- [ ] I think the output should be /build, rather than in .bos; although maybe something like bos-loader.json should stay in .bos

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -39,9 +39,10 @@ export async function buildApp(src: string, dest: string, network: string = "mai
     }
   });
 
-  const modules: string[] = [];
+  const modules: string[] = []; // init modules
   const widgets: string[] = [];
 
+  // we identify all the modules
   await loopThroughFiles(path.join(src, "module"), async (file: string) => {
     const ext = path.extname(file);
     if (ext === ".js" || ext === ".jsx" || ext === ".ts" || ext === ".tsx") {
@@ -50,6 +51,7 @@ export async function buildApp(src: string, dest: string, network: string = "mai
   })
 
   await loopThroughFiles(path.join(src, "widget"), async (file: string) => {
+    // we need this to do dot notation too
     const ext = path.extname(file);
     if (ext === ".js" || ext === ".jsx" || ext === ".ts" || ext === ".tsx") {
       widgets.push(file);
@@ -64,6 +66,7 @@ export async function buildApp(src: string, dest: string, network: string = "mai
     aliases,
   };
 
+  // module transpilation
   const loadingModules = log.loading(`Transpiling ${modules.length} modules`, LogLevels.BUILD);
   try {
     for (const file of modules) {
@@ -97,6 +100,7 @@ export async function buildApp(src: string, dest: string, network: string = "mai
     throw e;
   }
 
+  // widget transpilation
   const loadingWidgets = log.loading(`Transpiling ${widgets.length} widgets`, LogLevels.BUILD);
   try {
     for (const file of widgets) {
@@ -118,7 +122,7 @@ export async function buildApp(src: string, dest: string, network: string = "mai
 
       logs.push(...new_logs);
       // write to dest
-      let new_file_name = path.basename(file);
+      let new_file_name = path.basename(file); // this needs to build pathname from the dot notation
       new_file_name = new_file_name.substring(0, new_file_name.length - path.extname(file).length);
       new_file_name += ".jsx";
 

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -122,7 +122,7 @@ export async function buildApp(src: string, dest: string, network: string = "mai
 
       logs.push(...new_logs);
       // write to dest
-      let new_file_name = path.basename(file); // this needs to build pathname from the dot notation
+      let new_file_name = path.relative(path.join(src, "widget"), file).replace("/", ".");
       new_file_name = new_file_name.substring(0, new_file_name.length - path.extname(file).length);
       new_file_name += ".jsx";
 

--- a/lib/init.ts
+++ b/lib/init.ts
@@ -14,7 +14,7 @@ const templates = {
       name: "Hello",
       description: "Hello world widget",
     }),
-    "./widget/home.tsx": "const { hello } = VM.require('${module/hello/utils.ts}'); return hello();",
+    "./widget/home.tsx": "const { hello } = VM.require('${module/hello}') || { hello: () => console.log('hello') }; return hello();",
   },
   "js-multi": {
     "./bos.workspace.json": JSON.stringify({

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -256,7 +256,7 @@ export async function format(code: Code): Promise<Output> {
   const logs: Array<Log> = [];
   let new_code = code;
   try {
-    new_code = beautify(code, {
+    new_code = await beautify(code, {
       parser: "babel",
     });
   } catch (e: any) {

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -209,7 +209,7 @@ export function evalCustomSyntax(code: Code, params: EvalCustomSyntaxParams): Ou
         evl = evalAlias(path, params.aliases);
         break;
       default:
-        evl = evalAlias(expression, params.aliases);
+        return _match;
     };
     logs.push(...evl.logs);
     return evl.code;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@types/express": "^4.17.21",
-        "@types/gaze": "^1.1.5",
         "commander": "^11.1.0",
         "express": "^4.18.2",
         "fs-extra": "^11.2.0",
@@ -22,7 +20,9 @@
         "sucrase": "^3.34.0"
       },
       "devDependencies": {
+        "@types/express": "^4.17.21",
         "@types/fs-extra": "^11.0.4",
+        "@types/gaze": "^1.1.5",
         "@types/jest": "^29.5.11",
         "@types/node": "^20.10.4",
         "jest": "^29.7.0",
@@ -1299,6 +1299,7 @@
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -1308,6 +1309,7 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1329,6 +1331,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
       "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -1340,6 +1343,7 @@
       "version": "4.17.41",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
       "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1360,7 +1364,8 @@
     "node_modules/@types/gaze": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@types/gaze/-/gaze-1.1.5.tgz",
-      "integrity": "sha512-EUsdBWbKIDvlsPBhEPA8LMbpvJaUjr/APU89uPbfPoXdPOw9Q6beEhB3oyYBn621j6s8zUiR5OVhbyJLA/Ij/A=="
+      "integrity": "sha512-EUsdBWbKIDvlsPBhEPA8LMbpvJaUjr/APU89uPbfPoXdPOw9Q6beEhB3oyYBn621j6s8zUiR5OVhbyJLA/Ij/A==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -1374,7 +1379,8 @@
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -1422,7 +1428,8 @@
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "20.10.4",
@@ -1435,17 +1442,20 @@
     "node_modules/@types/qs": {
       "version": "6.9.11",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
-      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ=="
+      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
+      "dev": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -1455,6 +1465,7 @@
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
       "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
+      "dev": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/mime": "*",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bw",
+  "name": "bos-workspace",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -18,6 +18,7 @@
     "express": "^4.18.2",
     "fs-extra": "^11.2.0",
     "gaze": "^1.1.3",
+    "glob": "^10.3.10",
     "joi": "^17.11.0",
     "multilang-extract-comments": "^0.4.0",
     "prettier": "^2.8.8",
@@ -25,11 +26,11 @@
     "sucrase": "^3.34.0"
   },
   "devDependencies": {
+    "@types/express": "^4.17.21",
     "@types/fs-extra": "^11.0.4",
+    "@types/gaze": "^1.1.5",
     "@types/jest": "^29.5.11",
     "@types/node": "^20.10.4",
-    "@types/express": "^4.17.21",
-    "@types/gaze": "^1.1.5",
     "jest": "^29.7.0",
     "memfs": "^4.6.0",
     "ts-jest": "^29.1.1",

--- a/tests/unit/build.ts
+++ b/tests/unit/build.ts
@@ -47,7 +47,7 @@ const app_example_1_output = {
   "/build/ipfs.json": JSON.stringify({
     "logo.svg": "QmHash",
   }, null, 2) + "\n",
-  "/build/widget/hello.utils.module.js": "const hello = (name) => `Hello, world!`;\nreturn { hello };\n",
+  "/build/widget/hello.utils.module.js": "const hello = (name) => `Hello, ${name}!`;\nreturn { hello };\n",
   "/build/widget/index.jsx": "const hello = \"hi\";\nreturn hello(props);\n",
   "/build/widget/nested.index.jsx": "const hello = \"hi\";\nreturn hello(props);\n",
   "/build/widget/module.jsx": "VM.require(\"test.near/widget/hello.utils.module\");\nreturn hello(\"world\");\n",

--- a/tests/unit/build.ts
+++ b/tests/unit/build.ts
@@ -1,6 +1,7 @@
 import { buildApp } from '@/lib/build';
 import { BaseConfig, DEFAULT_CONFIG } from '@/lib/config';
 import * as fs from '@/lib/utils/fs';
+import { LogLevel, Logger } from "@/lib/logger";
 
 import { vol, } from 'memfs';
 jest.mock('fs', () => require('memfs').fs);
@@ -25,6 +26,11 @@ const app_example_1 = {
     name: "Hello",
     description: "Hello world widget",
   }),
+  "./widget/nested/index.tsx": "type Hello = {}; const hello: Hello = 'hi'; export default hello;",
+  "./widget/nested/index.metadata.json": JSON.stringify({
+    name: "Nested Hello",
+    description: "Nested Hello world widget",
+  }),
   "./widget/module.tsx": "VM.require('${module/hello/utils}'); export default hello('world');",
   "./widget/config.jsx": "return <h1>${config/account}${config / account / deploy}</h1>;",
   "./widget/alias.tsx": "export default <h1>Hello ${alias/name}!</h1>;",
@@ -43,6 +49,7 @@ const app_example_1_output = {
   }, null, 2) + "\n",
   "/build/widget/hello.utils.module.js": "const hello = (name) => `Hello, world!`;\nreturn { hello };\n",
   "/build/widget/index.jsx": "const hello = \"hi\";\nreturn hello(props);\n",
+  "/build/widget/nested.index.jsx": "const hello = \"hi\";\nreturn hello(props);\n",
   "/build/widget/module.jsx": "VM.require(\"test.near/widget/hello.utils.module\");\nreturn hello(\"world\");\n",
   "/build/widget/config.jsx": "return <h1>test.neartest.near</h1>;\n",
   "/build/widget/alias.jsx": "return <h1>Hello world!</h1>;\n",
@@ -63,6 +70,13 @@ const app_example_1_output = {
             name: "Hello",
             description: "Hello world widget",
           }
+        },
+        "nested.index": {
+          metadata: {
+            name: "Nested Hello",
+            description: "Nested Hello world widget",
+          }
+
         }
       }
     }
@@ -70,6 +84,7 @@ const app_example_1_output = {
 };
 
 const unmockedFetch = global.fetch;
+const unmockedLog = global.log;
 
 describe('build', () => {
   beforeEach(() => {
@@ -83,9 +98,11 @@ describe('build', () => {
         })
       })
     }) as any;
+    global.log = new Logger(LogLevel.DEV);
   })
   afterAll(() => {
     global.fetch = unmockedFetch;
+    global.log = unmockedLog;
   })
 
   it('should build correctly without logs', async () => {

--- a/tests/unit/parser.ts
+++ b/tests/unit/parser.ts
@@ -190,8 +190,6 @@ describe('evalCustomSyntax', () => {
       let module = "\${module/db}";
       let alias = "\${alias/util}";
       let ipfs = "\${ipfs/xyz}";
-      let other = "\${other/abc}";
-      let other1 = "\${REPL_HELLO}";
     `;
 
     const config = { accounts: { deploy: "user.near" } };
@@ -206,8 +204,27 @@ describe('evalCustomSyntax', () => {
       let module = "user.near/widget/db.module";
       let alias = "utility";
       let ipfs = "https://ipfs.org/bafkreihdwdcef3tkddpljak234nlasjd93j4asdhfas3";
-      let other = "other";
-      let other1 = "hello";
+    `,
+      logs: []
+    };
+
+    const result = evalCustomSyntax(code, { config, modules, aliases, ipfsMap, ipfsGateway });
+    expect(result).toEqual(expectedOutput);
+  });
+  it('should support default string literals', async () => {
+    const code = `
+      let styled = "\${(props) => (props.isConnected ? "green" : "red")}";
+    `;
+
+    const config = { accounts: { deploy: "user.near" } };
+    const modules = ["db"];
+    const aliases = { "util": "utility", "other/abc": "other", "REPL_HELLO": "hello" };
+    const ipfsMap = { "xyz": "bafkreihdwdcef3tkddpljak234nlasjd93j4asdhfas3" };
+    const ipfsGateway = "https://ipfs.org/";
+
+    const expectedOutput = {
+      code: `
+      let styled = "\${(props) => (props.isConnected ? "green" : "red")}";
     `,
       logs: []
     };

--- a/tests/unit/workspace.ts
+++ b/tests/unit/workspace.ts
@@ -1,0 +1,79 @@
+/**
+ * TODO: Fix the below tests
+ */
+
+import path from "path";
+import { buildApp } from "@/lib/build";
+import { readJson } from "@/lib/utils/fs";
+import { devMulti } from "@/lib/dev";
+import { buildWorkspace, devWorkspace, readWorkspace } from "@/lib/workspace";
+
+jest.mock("@/lib/build");
+jest.mock("@/lib/utils/fs");
+jest.mock("@/lib/dev");
+
+describe("buildWorkspace", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should build workspace correctly", async () => {
+    const src = "/path/to/src";
+    const dest = "/path/to/dest";
+    const network = "mainnet";
+    const mockApps = ["app1", "app2"];
+
+    readJson.mockResolvedValueOnce({ apps: mockApps });
+
+    await buildWorkspace(src, dest, network);
+
+    expect(readJson).toHaveBeenCalledWith(path.join(src, "bos.workspace.json"));
+    expect(buildApp).toHaveBeenCalledTimes(mockApps.length);
+    mockApps.forEach((app, index) => {
+      expect(buildApp).toHaveBeenNthCalledWith(index + 1, path.join(src, app), path.join(dest, app), network);
+    });
+  });
+
+  // Add more tests for error cases if needed
+});
+
+describe("devWorkspace", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should start workspace correctly", async () => {
+    const src = "/path/to/src";
+    const mockApps = ["app1", "app2"];
+    const devOpts = { /* mock your DevOptions object */ };
+
+    readJson.mockResolvedValueOnce({ apps: mockApps });
+
+    await devWorkspace(src, devOpts);
+
+    expect(readJson).toHaveBeenCalledWith(path.join(src, "bos.workspace.json"));
+    expect(devMulti).toHaveBeenCalledWith(src, mockApps.map(app => path.join(src, app)), devOpts);
+  });
+
+  // Add more tests for error cases if needed
+});
+
+describe("readWorkspace", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should read workspace correctly", async () => {
+    const src = "/path/to/src";
+    const mockConfig = { apps: ["app1", "app2"] };
+
+    readJson.mockResolvedValueOnce(mockConfig);
+
+    const result = await readWorkspace(src);
+
+    expect(readJson).toHaveBeenCalledWith(src);
+    expect(result).toEqual(mockConfig);
+  });
+
+  // Add more tests for error cases if needed
+});


### PR DESCRIPTION
## Feedback:

See an app that I initialized to test bos-workspace here: https://github.com/NEARBuilders/buildbox/tree/bw-wip

I really like the new alias pattern -- alias/name, config/account, module/hello.
The testnet override is much needed atm, glad to see it. 

### High Priority
- [ ] build after testing throws tsc error
- [ ] init without project name throws error "[path] argument is required"
- [x] home doesn't run because "hello" is not a function (need to default VM.require, fix in "init")
- [ ] newly initialized typescript files are throwing errors, we need to include package.json, eslint, tsconfig, etc... (open to choose typescript or javascript) in the init
- [ ] I think module/hello should match: module.hello rather than hello.module (or we should remove this pattern)
- [ ] I think the output should be /build, rather than in .bos; although maybe something like bos-loader.json should stay in .bos
- [x] It's not reading nested widgets (widget/page/home is not building or resolving from bosworkspace/widget/page.home)

### Lower Priority
- [ ] socket connects and disconnects, why?
- [ ] how could bw init be configured with template repositories rather than static files?
- [ ] We could prompt the account name during bw init
- [ ] Idk what error, but hot-reload was killed once during editing (exception handling)


We'll also need to implement [Mattb's recent change](https://github.com/NEARBuilders/bos-workspace/commit/e4d6cec9c004b226f45c10c2b217c72030a64abb) for clone, pull, delete