### PR TITLE
adds support for index widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist/**/*
 __app_example_1/
 
 */temp/**/*
+**/data.json

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The `bos.config.json` file consists of a base configuration that defines default
   * `uploadApiHeaders`: Any additional headers to send with IPFS upload API requests.
 * `format`: (Optional) Indicates whether to format code on build. Default value is `true`.
 * `aliases`: (Optional) Provides a list of alias files to use for replacing network-specific values with correct overrides.
+* `index`: (Optional) Default widget src to use when using a custom gateway dist.  
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,19 +12,29 @@
 
 ## Quickstart
 
-To begin, either [use this template repository](https://github.com/new?template_name=quickstart&template_owner=NEARBuilders) or install `bos-workspace` within an existing project:
+To begin, either:
+
+* [Use the template repository](https://github.com/new?template_name=quickstart&template_owner=NEARBuilders) with quickstart app, preconfigured git workflows, playwright test suite
+
+* Use the init command for an empty workspace:
+
+```cmd
+npx bos-workspace init [configAccount]
+```
+
+* Clone widgets from an existing [account](https://near.social/mob.near/widget/Everyone):
+
+```cmd
+npx bos-workspace clone [accountId] [dest]
+```
+
+* Or install `bos-workspace` within an existing project:
 
 ```cmd
 yarn add -D bos-workspace
 ```
 
-Then, you can clone widgets from an existing [account](https://near.social/mob.near/widget/Everyone) via:
-
-```bash
-yarn run bos-workspace clone [accountId] [dest]
-```
-
-Or ensure the proper workspace [structure and usage](#usage).
+and ensure the proper workspace [structure and usage](#usage).
 
 ## Usage
 
@@ -39,7 +49,7 @@ app.near/
 └── bos.config.json
 ```
 
-where the content of `bos.config.json` is:
+where the content of `bos.config.json` is (at least):
 
 ```json
 {
@@ -72,6 +82,109 @@ where the content of `bos.workspace.json` is:
 
 **Note:** The "app name" is not required to end in `.near`, and apps don't necessarily have to be stored in a directory named `/apps`. What's important is that the `bos.config.json` is located at the same level as directories such as `/widget`, and that `bos.workspace.json` specifies the directory it resides in.
 
+## bos.config.json
+
+The `bos.config.json` file serves as the configuration file for managing various settings and options related to the workspace.
+
+A fully featured config may look like this:
+
+```json
+{
+  "account": "quickstart.near",
+  "aliases": ["./aliases.mainnet.json"],
+  "index": "quickstart.near/widget/home",
+  "overrides": {
+    "testnet": {
+      "account": "quickstart.testnet",
+      "aliases": ["./aliases.testnet.json"],
+      "index": "quickstart.testnet/widget/home"
+    }
+  },
+  "accounts": {
+    "deploy": "quickstart.near",
+    "signer": "devs.near",
+  },
+  "format": true,
+  "ipfs": {
+    "gateway": "https://ipfs.near.social/ipfs",
+    "uploadApi": "https://ipfs.near.social/add",
+    "uploadApiHeaders": {},
+  },
+}
+```
+
+---
+
+### Base Configuration
+
+The `bos.config.json` file consists of a base configuration that defines default values and settings for the BOS environment.
+
+* `account`: (Optional) Specifies the default account to serve widgets from. If not provided, the default value is set to `"bos.workspace"`.
+* `accounts`: (Optional) Defines account configuration options for the `deploy` command.
+  * `deploy`: Specifies the account to deploy widgets to.
+  * `signer`: Specifies the account to sign the transaction.
+* `ipfs`: (Optional) Configures IPFS settings for uploading and using local assets.
+  * `gateway`: IPFS gateway to use for accessing files. Default value is `"https://ipfs.near.social/ipfs"`.
+  * `uploadApi`: IPFS API endpoint to upload to. Default value is `"https://ipfs.near.social/add"`.
+  * `uploadApiHeaders`: Any additional headers to send with IPFS upload API requests.
+* `format`: (Optional) Indicates whether to format code on build. Default value is `true`.
+* `aliases`: (Optional) Provides a list of alias files to use for replacing network-specific values with correct overrides.
+
+---
+
+### Network Configuration Overrides
+
+The `bos.config.json` file supports network configuration overrides of this base configuration, allowing developers to specify different settings for specific networks (e.g., mainnet, testnet).
+
+* `overrides`: (Optional) Defines overrides for network-specific configurations. These values are used via the `-n` flag in commands, respectivly:
+  * `mainnet`
+  * `testnet`
+
+---
+
+### Aliases
+
+When working with values that differ accross different networks, developers can define aliases in separate JSON files according to environment.
+
+* **Account**: Defines the "owner" of the widgets in the workspace, according to network.
+  * Pattern: `{CONFIG_ACCOUNT}`
+* **Aliases**: Defines patterns for replacing other account and contract references. These are particularly useful for widget sources accross environments, such as using mob.near for mainnet, and mike.testnet for testnet.
+  * Pattern: `${ALIAS_KEY}`
+  * Example:
+
+    ```json
+    {
+      "account": "[MAINNET_ACCOUNT_ID]",
+      "aliases": ["./aliases.mainnet.json"],
+      "overrides": {
+        "testnet": {
+          "account": "[TESTNET_ACCOUNT_ID]",
+          "aliases": ["./aliases.testnet.json"]
+        }
+      }
+    }
+    ```
+
+    with accompaning jsons:
+
+    `aliases.mainnet.json`
+
+    ```json
+    {
+      "devs": "devs.near",
+      "mob": "mob.near",
+    }
+    ```
+
+    `aliases.testnet.json`
+
+    ```json
+    {
+      "devs": "neardevs.testnet",
+      "mob": "mike.testnet"
+    }
+    ```
+
 ## Commands
 
 You can run `bw` or `bos-workspace` to see the list of commands.
@@ -99,6 +212,89 @@ Commands:
 
 > If the gateway can't fetch local components, try disabling brave shields or your adblock.
 > If the commands don't work, try again using Node >=16
+
+## Deployment
+
+**Command:** `deploy`
+
+Deploys an app in the workspace via a convenient wrapper to [bos-cli-rs](https://github.com/bos-cli-rs/bos-cli-rs).
+
+### Usage (CLI)
+
+Deploy the project with the option to specify an app name (must be the name of the folder in the /apps directory):
+
+```cmd
+bos-workspace deploy [app name] --deploy-account-id [deployAccountId] --signer-account-id [signerAccountId] --signer-public-key [signerPublicKey] --signer-private-key [signerPrivateKey]
+```
+
+### Options
+
+* `--deploy-account-id <deployAccountId>` (Optional): Account under which component code should be deployed. Defaults to `config.account`, or will use `config.accounts.deploy` if specified.
+
+* `--signer-account-id <signerAccountId>` (Optional): Account which will be used for signing deploy transactions, frequently the same as deploy-account-id. Defaults to `config.account`, or will use `config.accounts.deploy` if specified.
+
+* `--signer-public-key <signerPublicKey>` (Required): Public key for signing transactions in the format: `ed25519:<public_key>`.
+
+* `--signer-private-key <signerPrivateKey>` (Required): Private key in `ed25519:<private_key>` format for signing transactions.
+
+* `-n, --network <network>` (Optional): Network to deploy for (default: "mainnet").
+
+## Configuring git workflows
+
+### Prerequisites
+
+1. Must be upgraded to bos-workspace v1, see the [migration guide](?page=getting_started/migration_guide)
+2. Specify testnet [overrides + aliases](?page=usage/aliases) in bos.config.json.
+
+
+### Mainnet
+
+1. Create `.github/workflow/release-mainnet.yml`
+
+```yml
+name: Deploy Components to Mainnet
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy-mainnet:
+    uses: NEARBuilders/bos-workspace/.github/workflows/deploy.yml@main
+    with:
+      bw-legacy: false
+      deploy-env: "mainnet"
+      app-name: "[APP_NAME]"
+      deploy-account-address: "[DEPLOY_ACCOUNT]"
+      signer-account-address: "[SIGNER_ACCOUNT]"
+      signer-public-key: [PUBLIC_KEY]
+    secrets:
+      SIGNER_PRIVATE_KEY: ${{ secrets.SIGNER_PRIVATE_KEY }} // then configure this in your Github/Settings/Actions
+```
+
+### Testnet
+
+1. Create `.github/workflow/release-testnet.yml`
+
+```yml
+name: Deploy Components to Testnet
+on:
+  push:
+    branches: [develop]
+jobs:
+  deploy-mainnet:
+    uses: NEARBuilders/bos-workspace/.github/workflows/deploy.yml@main
+    with:
+      bw-legacy: false
+      build-env: "testnet"
+      deploy-env: "testnet"
+      app-name: "[APP_NAME]"
+      deploy-account-address: "[DEPLOY_ACCOUNT]" // testnet account
+      signer-account-address: "[SIGNER_ACCOUNT]"
+      signer-public-key: [PUBLIC_KEY] 
+    secrets:
+      SIGNER_PRIVATE_KEY: ${{ secrets.SIGNER_PRIVATE_KEY }} // then configure this in your Github/Settings/Actions
+```
+
+Reference: [quickstart](https://github.com/nearbuilders/quickstart)
 
 ## API Endpoints
 

--- a/examples/multi/apps/GoodbyeNothing/data.json
+++ b/examples/multi/apps/GoodbyeNothing/data.json
@@ -1,3 +1,0 @@
-{
-  "goodbyenothing.near": {}
-}

--- a/examples/multi/apps/HelloWorld/data.json
+++ b/examples/multi/apps/HelloWorld/data.json
@@ -1,3 +1,0 @@
-{
-  "helloworld.near": {}
-}

--- a/examples/single/bos.config.json
+++ b/examples/single/bos.config.json
@@ -1,10 +1,12 @@
 {
   "account": "quickstart.near",
   "aliases": ["./aliases.mainnet.json"],
+  "index": "quickstart.near/widget/home",
   "overrides": {
     "testnet": {
       "account": "quickstart.testnet",
-      "aliases": ["./aliases.testnet.json"]
+      "aliases": ["./aliases.testnet.json"],
+      "index": "quickstart.testnet/widget/home"
     }
   }
 }

--- a/examples/single/data.json
+++ b/examples/single/data.json
@@ -1,3 +1,0 @@
-{
-  "quickstart.near": {}
-}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -4,20 +4,19 @@ import { Network } from './types';
 import path from 'path';
 
 export interface BaseConfig {
-  account?: string;
-  accounts?: {
-    deploy?: string;
-    signer?: string;
-    dev?: string;
+  account?: string; // default account to serve widgets from
+  accounts?: { // account configuration (used for deploy command)
+    deploy?: string; // account to deploy widgets to
+    signer?: string; // account to sign transactions (such as deployment)
   };
-  ipfs?: {
-    gateway?: string;
-    uploadApi?: string;
-    uploadApiHeaders?: Record<string, string>;
+  ipfs?: { // ipfs configuration
+    gateway?: string; // ipfs gateway to use
+    uploadApi?: string; // ipfs upload api
+    uploadApiHeaders?: Record<string, string>; // headers to send with ipfs upload api
   };
-  format?: boolean;
-  aliases?: string[];
-  index?: string;
+  format?: boolean; // option to format code on build (default true)
+  aliases?: string[]; // list of alias to use
+  index?: string; // widget to use as index
 }
 
 interface NetworkConfig {
@@ -44,7 +43,6 @@ export const DEFAULT_CONFIG = {
 const accountConfigSchema = Joi.object({
   deploy: Joi.string().allow(null),
   signer: Joi.string().allow(null),
-  dev: Joi.string().allow(null),
 });
 
 const baseConfigSchema = Joi.object({
@@ -101,7 +99,6 @@ function fillInAccounts(config: AppConfig): AppConfig {
     accounts: {
       deploy: config.accounts?.deploy || config.account,
       signer: config.accounts?.signer || config.account,
-      dev: config.accounts?.dev || config.account,
     },
   };
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -8,6 +8,7 @@ export interface BaseConfig {
   accounts?: { // account configuration (used for deploy command)
     deploy?: string; // account to deploy widgets to
     signer?: string; // account to sign transactions (such as deployment)
+    dev?: string; 
   };
   ipfs?: { // ipfs configuration
     gateway?: string; // ipfs gateway to use
@@ -43,6 +44,7 @@ export const DEFAULT_CONFIG = {
 const accountConfigSchema = Joi.object({
   deploy: Joi.string().allow(null),
   signer: Joi.string().allow(null),
+  dev: Joi.string().allow(null),
 });
 
 const baseConfigSchema = Joi.object({
@@ -99,6 +101,7 @@ function fillInAccounts(config: AppConfig): AppConfig {
     accounts: {
       deploy: config.accounts?.deploy || config.account,
       signer: config.accounts?.signer || config.account,
+      dev: config.accounts?.dev || config.account,
     },
   };
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -17,6 +17,7 @@ export interface BaseConfig {
   };
   format?: boolean;
   aliases?: string[];
+  index?: string;
 }
 
 interface NetworkConfig {
@@ -56,6 +57,7 @@ const baseConfigSchema = Joi.object({
   }).default(DEFAULT_CONFIG.ipfs),
   format: Joi.boolean().default(DEFAULT_CONFIG.format),
   aliases: Joi.array().items(Joi.string()).default(DEFAULT_CONFIG.aliases),
+  index: Joi.string().allow(null),
 });
 
 const networkConfigSchema = Joi.object({

--- a/lib/dev.ts
+++ b/lib/dev.ts
@@ -13,12 +13,13 @@ import { startFileWatcher } from "./watcher";
 const DEV_DIST_FOLDER = "build";
 
 export type DevOptions = {
-  port?: number;
-  NoGateway?: boolean;
-  NoHot?: boolean;
-  NoOpen?: boolean;
-  network?: Network;
-  gateway?: string;
+  port?: number; // port to run dev server
+  NoGateway?: boolean; // disable local gateway
+  NoHot?: boolean; // disable hot reloading
+  NoOpen?: boolean; // do not open browser
+  network?: Network; // network to use
+  gateway?: string; // path to custom gateway dist
+  index?: string; // widget to use as index
 };
 
 /**
@@ -38,6 +39,11 @@ export async function dev(src: string, opts: DevOptions) {
   // Build the app for the first time
   let devJson = await generateApp(src, dist, config, opts, devJsonPath);
   await writeJson(devJsonPath, devJson);
+
+  // set index widget (temp, this can be done better)
+  if (!opts.index && config.index) {
+    opts.index = config.index;
+  }
 
   // Start the dev server
   const server = startDevServer(devJsonPath, opts);

--- a/lib/gateway.ts
+++ b/lib/gateway.ts
@@ -30,6 +30,7 @@ export const handleReplacements = (html: string, opts: DevOptions): string => {
       pattern: /<near-social-viewer><\/near-social-viewer>/g,
       replacement: true
         ? `<near-social-viewer
+        ${renderAttribute("src", opts.index)}
         ${renderAttribute("rpc", `http://127.0.0.1:${opts.port}/api/proxy-rpc`)}></near-social-viewer>`
         : "<near-social-viewer></near-social-viewer>",
     }

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -4,14 +4,6 @@ import fs, { existsSync, outputFile, writeFile } from "fs-extra";
 import path from "path";
 import { SHA256 } from "crypto-js";
 
-/*
-// Implement cloneRepository, pullRepository, and removeRepository functions
-// pull from repository.js
-// cloneRepository(account, dest);
-// pullRepository(account, dest);
-// removeRepository(account, dest);
-*/
-
 const NEAR_MAINNET_RPC = "https://rpc.mainnet.near.org/";
 const TREE_DIR = "./tree.json";
 

--- a/tests/unit/gateway.ts
+++ b/tests/unit/gateway.ts
@@ -20,6 +20,7 @@ describe("gateway", () => {
     port: 8080,
     NoHot: false,
     network: 'testnet' as Network,
+    index: "test/widget/index"
   };
 
   // Test replacement of environment configuration
@@ -40,7 +41,7 @@ describe("gateway", () => {
   // Test replacement of the near-social-viewer component with an RPC attribute
   it("should replace <near-social-viewer></near-social-viewer> with near-social-viewer having an RPC attribute", () => {
     const htmlInput = "<html><head></head><body><near-social-viewer></near-social-viewer></body></html>";
-    const expectedHtmlOutput = `<html><head></head><body><near-social-viewer rpc="http://127.0.0.1:8080/api/proxy-rpc"></near-social-viewer></body></html>`;
+    const expectedHtmlOutput = `<html><head></head><body><near-social-viewer src="${mockOpts.index}" rpc="http://127.0.0.1:${mockOpts.port}/api/proxy-rpc"></near-social-viewer></body></html>`;
 
     const result = handleReplacements(htmlInput, mockOpts);
     expect(result).toBe(expectedHtmlOutput);


### PR DESCRIPTION
As part of [Move "default widget src" replacement to bos-workspace](https://github.com/orgs/NEARBuilders/projects/5/views/1?pane=issue&itemId=62932847).

Enables developers to define an "index" to use as default route when using a custom gateway dist via `-g` command.