### PR TITLE
feat: configurable alias prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ When working with values that differ accross different networks, developers can 
 * **Account**: Defines the "owner" of the widgets in the workspace, according to network.
   * Pattern: `{config_account}`
 * **Aliases**: Defines patterns for replacing other account and contract references. These are particularly useful for widget sources accross environments, such as using mob.near for mainnet, and mike.testnet for testnet.
-  * Pattern: `${alias_key}`
+  * Pattern: `${alias_key}` ( note that you may also have other prefixes than `alias_` by configuring the `aliasPrefix` property )
   * Example:
 
     ```json
@@ -186,6 +186,40 @@ When working with values that differ accross different networks, developers can 
       "mob": "mike.testnet"
     }
     ```
+
+#### Custom alias prefix
+
+If your aliases are prefixed with another keyword than `alias`, you may configure this using the `aliasPrefix` property. You may also include the prefix in the keys of your alias json file. Here is an example:
+
+ ```json
+  {
+    "account": "[MAINNET_ACCOUNT_ID]",
+    "aliases": ["./aliases.mainnet.json"],
+    "aliasPrefix": "REPL",
+    "aliasesContainsPrefix": true,
+  }
+```
+
+and then with your `aliases.mainnet.json` like this:
+
+
+```json
+{
+  "REPL_NAME": "world"
+}
+```
+
+If your widget file looks like this:
+
+```tsx
+export default <h1>Hello ${REPL_NAME}!</h1>;
+```
+
+Then the alias will be replaced like this:
+
+```tsx
+export default <h1>Hello world!</h1>;
+```
 
 ## Customizing the Gateway
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -18,6 +18,8 @@ export interface BaseConfig {
   format?: boolean; // option to format code on build (default true)
   aliases?: string[]; // list of alias to use
   index?: string; // widget to use as index
+  aliasPrefix?: string; // prefix to use for aliases, default is "alias"
+  aliasesContainsPrefix?: boolean; // aliases keys contains prefix (default is false)
 }
 
 interface NetworkConfig {
@@ -57,6 +59,8 @@ const baseConfigSchema = Joi.object({
   }).default(DEFAULT_CONFIG.ipfs),
   format: Joi.boolean().default(DEFAULT_CONFIG.format),
   aliases: Joi.array().items(Joi.string()).default(DEFAULT_CONFIG.aliases),
+  aliasPrefix: Joi.string().allow(null),
+  aliasesContainsPrefix: Joi.boolean().allow(null),
   index: Joi.string().allow(null),
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bos-workspace",
-  "version": "1.0.0-alpha.26",
+  "version": "1.0.0-alpha.27",
   "description": "",
   "bin": {
     "bos-workspace": "./bin/bw.js",

--- a/tests/unit/build.ts
+++ b/tests/unit/build.ts
@@ -168,6 +168,26 @@ const app_example_2_output = {
   }, null, 2) + "\n",
 };
 
+const app_example_3 = {
+  "./bos.config.json": JSON.stringify({
+    ...DEFAULT_CONFIG,
+    aliasPrefix: "REPL",
+    aliasesContainsPrefix: true,
+    account: "test.near",
+  }),
+  "./aliases.json": JSON.stringify({
+    "REPL_NAME": "world",
+  }),
+  "./widget/alias.tsx": "export default <h1>Hello ${REPL_NAME}!</h1>;",
+};
+
+const app_example_3_output = {
+  "/build/data.json": JSON.stringify({
+    "test.near": {}
+  }, null, 2) + "\n",
+  "/build/src/widget/alias.jsx": "return <h1>Hello world!</h1>;\n",
+};
+
 const unmockedFetch = global.fetch;
 const unmockedLog = global.log;
 
@@ -202,5 +222,10 @@ describe('build', () => {
     vol.fromJSON(app_example_2, '/app_example_2');
     await buildApp('/app_example_2', '/build');
     expect(vol.toJSON('/build')).toEqual(app_example_2_output);
+  })
+  it('should support custom alias', async () => {
+    vol.fromJSON(app_example_3, '/app_example_3');
+    await buildApp('/app_example_3', '/build');
+    expect(vol.toJSON('/build')).toEqual(app_example_3_output);
   })
 })


### PR DESCRIPTION
Configurable Alias is about having the option to not only use the `alias_` when referencing common constants in your code. This can be references to a near account, an external URL or whatever you need to reference in your code.

In the updated documentation you can read about the new `aliasPrefix` and `aliasesContainsPrefix` settings, which gives you the option to use another prefix than `alias` and also that your aliases file contains the prefix itself in the names of the object keys.

Here's from the "Custom alias prefix" section of the documentation:

If your aliases are prefixed with another keyword than `alias`, you may configure this using the `aliasPrefix` property. You may also include the prefix in the keys of your alias json file. Here is an example:

 ```json
  {
    "account": "[MAINNET_ACCOUNT_ID]",
    "aliases": ["./aliases.mainnet.json"],
    "aliasPrefix": "REPL",
    "aliasesContainsPrefix": true,
  }
```

and then with your `aliases.mainnet.json` like this:


```json
{
  "REPL_NAME": "world"
}
```

If your widget file looks like this:

```tsx
export default <h1>Hello ${REPL_NAME}!</h1>;
```

Then the alias will be replaced like this:

```tsx
export default <h1>Hello world!</h1>;
```

This update also makes it more compatible with [bos-loader](https://github.com/near/bos-loader) so that you can more easily use existing project with replacement configurations with bos-workspaces.

fixes #109